### PR TITLE
Updating Jackson version to address all open CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.7</java.version>
         <spring.version>3.2.17.RELEASE</spring.version>
-        <jackson.version>2.8.4</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j2.version>2.7</log4j2.version>
         <mockito.version>2.2.9</mockito.version>


### PR DESCRIPTION
The Jackson version used has several open CVEs against it:

CVE-2019-16335
CVE-2019-14540
CVE-2019-12384
CVE-2019-14379
CVE-2019-14439
CVE-2019-12814
CVE-2018-11307
CVE-2019-12086
CVE-2018-12022
CVE-2018-19360
CVE-2018-14719
CVE-2018-14720
CVE-2018-19362
CVE-2018-14718
CVE-2018-14721
CVE-2018-19361
CVE-2017-15095
CVE-2017-17485
CVE-2018-7489
CVE-2017-7525

Updating the version to the latest 2.x.x (2.10.0), which still maintains the Java 7 requirement.